### PR TITLE
Prefill ipa-redisearch in testing env

### DIFF
--- a/containers/docker-compose.testing.yml
+++ b/containers/docker-compose.testing.yml
@@ -28,3 +28,8 @@ services:
         volume:
           nocopy: true
       - application-logs:${APP_LOGS_PATH_CONTAINER}
+
+# ipa-redisearch
+  ipa-redisearch:
+    volumes:
+      - ./ipa-redisearch/persistence:/bitnami/redis/data


### PR DESCRIPTION
Questa modifica dovrebbe evitare il fail in CI
```
1) Tests\Feature\CRUDWebsiteTest::testStorePrimaryWebsiteSuccessful
Session has unexpected errors: 

[
    "Il codice IPA della PA selezionata non è corretto."
]
Failed asserting that true is false.
```
dovuto al fatto che l'indice IPA non fa in tempo ad essere caricato su ipa-redisearch prima dell'inizio dei test.